### PR TITLE
Update the search contract term from 'foo' to 'park'

### DIFF
--- a/contracts/itpeople-app-itpeople-functions.json
+++ b/contracts/itpeople-app-itpeople-functions.json
@@ -367,7 +367,7 @@
       "request": {
         "method": "GET",
         "path": "/search",
-        "query": "term=foo",
+        "query": "term=park",
         "headers": {
           "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxOTE1NTQ0NjQzIiwidXNlcl9pZCI6IjEiLCJ1c2VyX25hbWUiOiJqb2huZG9lIn0.9uerDlhPKrtBrMMHuRoxbJ5x0QA7KOulDEHx9DKXpnQ"
         }

--- a/src/contracts.pact.test.ts
+++ b/src/contracts.pact.test.ts
@@ -188,7 +188,7 @@ describe('Contracts', () => {
 
     describe('for searches', () => {
 
-      it('searches for foo', async () => {
+      it('searches for "park"', async () => {
         const path = '/search'
         const resource = (await getFixture(path)).data
         expect(resource).not.toEqual({})
@@ -200,7 +200,7 @@ describe('Contracts', () => {
             headers: authHeader,
             path: path,
             query: {
-              term: "foo"
+              term: "park"
             }
           },
           willRespondWith: {
@@ -211,7 +211,7 @@ describe('Contracts', () => {
             body: deepMatchify(resource)
           }
         })
-        const responseBody = (await getPact(path + "?term=foo")).data
+        const responseBody = (await getPact(path + "?term=park")).data
         expect(responseBody).not.toEqual({})
       })
     })


### PR DESCRIPTION
This PR just changes the term used in the search contract to something that would yield a real result in with our Parks and Rec  data fakes.