### PR TITLE
Fix some unit navigation bugs.

### DIFF
--- a/src/components/Unit/Presentation/ChildrenCard.tsx
+++ b/src/components/Unit/Presentation/ChildrenCard.tsx
@@ -11,22 +11,18 @@ export const ChildrenCard: React.SFC<IProps> = (props) => {
     return (
         <>
             {
-                children && children.length &&
-                <>
-                    {
-                        children.map((child, i) => (
-                            <Row key={i}>
-                                <Col sm={2}><ChildrenUnitsIcon width="100%" /></Col>
-                                <Col>
-                                    <div className="related-group rvt-m-bottom-md" id="user-research">
-                                        <a href={`/units/${child.id}`} className="rvt-m-bottom-remove related-group-item-name rvt-text-bold">{child.name}</a>
-                                        <p className="rvt-ts-14 rvt-m-top-remove rvt-m-bottom-remove">{child.description}</p>
-                                    </div>
-                                </Col>
-                            </Row>
-                        ))
-                    }
-                </>
+                children &&
+                children.map((child, i) => (
+                    <Row key={i}>
+                        <Col sm={2}><ChildrenUnitsIcon width="100%" /></Col>
+                        <Col>
+                            <div className="related-group rvt-m-bottom-md" id="user-research">
+                                <a href={`/units/${child.id}`} className="rvt-m-bottom-remove related-group-item-name rvt-text-bold">{child.name}</a>
+                                <p className="rvt-ts-14 rvt-m-top-remove rvt-m-bottom-remove">{child.description}</p>
+                            </div>
+                        </Col>
+                    </Row>
+                ))
             }
         </>
     )

--- a/src/components/Unit/Presentation/ParentCard.tsx
+++ b/src/components/Unit/Presentation/ParentCard.tsx
@@ -16,7 +16,7 @@ export const ParentCard: React.SFC<IProps> = (props) => {
                     <Row>
                         <Col sm={2}> <ParentUnitIcon width="100%" /> </Col>
                         <Col>
-                        <a href={parent.id + ""} className="rvt-m-bottom-remove related-group-item-name rvt-text-bold">{parent.name}</a>
+                        <a href={`/units/${parent.id}`} className="rvt-m-bottom-remove related-group-item-name rvt-text-bold">{parent.name}</a>
                         {parent.description &&
                             <p className="rvt-ts-14 rvt-m-top-remove rvt-m-bottom-remove">{parent.description}</p>
                         }


### PR DESCRIPTION
+ The link to the parent unit was erroneously relative to the current location.
+ `0` would appear if there were no children.