### PR TITLE
Feature/hr lookup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
   "version": "0.2.0",
   "configurations": [
+
     {
       "type": "chrome",
       "request": "launch",
@@ -25,12 +26,27 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "json-server",
+      "name": "json-server chaos",
       "program": "${workspaceFolder}/node_modules/.bin/json-server",
       "args": [
         "--watch", "json_server/db.json", 
         "--routes", "json_server/db.routes.json", 
         "--middlewares", "json_server/db.middleware.chaos.js", 
+        "--port", "3001"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "json-server admin",
+      "program": "${workspaceFolder}/node_modules/.bin/json-server",
+      "args": [
+        "--watch", "json_server/db.json", 
+        "--routes", "json_server/db.routes.json", 
+        "--middlewares", "json_server/db.middleware.admin.js", 
         "--port", "3001"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",

--- a/contracts/itpeople-app-itpeople-functions.json
+++ b/contracts/itpeople-app-itpeople-functions.json
@@ -341,6 +341,64 @@
       }
     },
     {
+      "description": "a POST request to create a membership from netID",
+      "providerState": "membership from netID may be created",
+      "request": {
+        "method": "POST",
+        "path": "/memberships",
+        "headers": {
+          "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOiIxOTE1NTQ0NjQzIiwidXNlcl9pZCI6IjEiLCJ1c2VyX25hbWUiOiJqb2huZG9lIn0.9uerDlhPKrtBrMMHuRoxbJ5x0QA7KOulDEHx9DKXpnQ",
+          "Content-Type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "id": 1,
+          "unitId": 1,
+          "netId": "rswanso",
+          "title": "title",
+          "role": "Leader",
+          "percentage": 100,
+          "permissions": "Viewer"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+        },
+        "body": {
+          "id": 1,
+          "unitId": 1,
+          "personId": 1,
+          "title": "title",
+          "role": "Leader",
+          "percentage": 100,
+          "permissions": "Viewer"
+        },
+        "matchingRules": {
+          "$.body.id": {
+            "match": "type"
+          },
+          "$.body.unitId": {
+            "match": "type"
+          },
+          "$.body.personId": {
+            "match": "type"
+          },
+          "$.body.title": {
+            "match": "type"
+          },
+          "$.body.role": {
+            "match": "type"
+          },
+          "$.body.percentage": {
+            "match": "type"
+          },
+          "$.body.permissions": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
       "description": "a GET request for all departments",
       "providerState": "at least one department exists",
       "request": {

--- a/json_server/db.middleware.admin.js
+++ b/json_server/db.middleware.admin.js
@@ -1,10 +1,19 @@
+const db = require("../src/db.json");
 module.exports = (req, res, next) => {
+  
+  // lookup person ID if netId provided when saving membership
+  if ((req.path = "/memberships") && (req.method == "POST" || req.method == "PUT") && req.body.netId) {
+      const person = db.people.find(p => p.netId == req.body.netId);
+      if(person) req.body.personId = person.id;
+  }
+
   // Admin with read/write/create/delete permission to every resource
   if (!req.get("Authorization") && req.path != "/auth") {
-    res.sendStatus(401)
+    res.sendStatus(401);
   } else {
     res.header("Access-Control-Expose-Headers", "X-User-Permissions");
     res.header("X-User-Permissions", "GET, PUT, POST, DELETE");
   }
+
   next();
 };

--- a/json_server/db.routes.json
+++ b/json_server/db.routes.json
@@ -7,6 +7,7 @@
   "/people/:id/memberships/:mid": "/memberships/:mid?_expand=unit",
   "/people/:id/memberships": "/memberships?personId=:id&_expand=unit",
   "/people/:id": "/people/:id?_expand=department",
+  "/people-lookup?q=:term": "/people?q=:term",
   "/departments/:id/members": "/people?departmentId=:id",
   "/departments/:id/memberUnits": "/units?id=1&id=2&id=4",
   "/departments/:id/supportingUnits": "/supportRelationships?departmentId=:id&_expand=unit"

--- a/src/api.pact.contract.ts
+++ b/src/api.pact.contract.ts
@@ -116,7 +116,7 @@ const getOne = (name: string, path: string, body: any) =>
         .then(getFromPactServer(path))
         .then(expectOK);
 
-const create = (name: string, path: string, body: any) =>
+const create = (name: string, path: string, body: any, responseBody?: any) =>
     pactServer
         .addInteraction({
             state: `${name} may be created`,
@@ -129,13 +129,13 @@ const create = (name: string, path: string, body: any) =>
             },
             willRespondWith: {
                 status: 201,
-                body: deepMatchify(body)
+                body: deepMatchify(responseBody || body)
             }
         })
         .then(postToPactServer(path, body))
         .then(expectCreated);
 
-const update = (name: string, path: string, body: any) =>
+const update = (name: string, path: string, body: any, responseBody?: any) =>
     pactServer
         .addInteraction({
             state: `${name} exists`,
@@ -151,7 +151,7 @@ const update = (name: string, path: string, body: any) =>
                 body: deepMatchify(body)
             }
         })
-        .then(putToPactServer(path, body))
+        .then(putToPactServer(path, responseBody || body))
         .then(expectOK);
 
 
@@ -192,6 +192,16 @@ const referenceUnitMemberRequest: IUnitMemberRequest = {
     percentage: 100,
     permissions: "Viewer"
 };
+const referenceUnitMemberRequestByNetId: IUnitMemberRequest = {
+    id: 1,
+    unitId: referenceUnit.id,
+    netId: referencePerson.netId,
+    title: "title",
+    role: "Leader",
+    percentage: 100,
+    permissions: "Viewer"
+};
+
 const referenceUnitMember: IUnitMember = {
     ...referenceUnitMemberRequest,
     person: referencePerson,
@@ -279,6 +289,13 @@ describe('Contracts', () => {
             await update(resource, itemPath, referenceUnitMemberRequest))
         it('deletes an existing membership', async () =>
             await delete_(resource, itemPath))
+
+        const resourceByNetId = 'membership from netID'
+        // With netId instead of personId
+        it('creates a new membership from netID', async () =>
+            await create(resourceByNetId, setPath, referenceUnitMemberRequestByNetId, referenceUnitMemberRequest))
+        it('updates an existing membership', async () =>
+            await update(resourceByNetId, itemPath, referenceUnitMemberRequestByNetId, referenceUnitMemberRequest))
     })
 
     describe('Departments', () => {

--- a/src/components/Unit/Forms/AddMemberForm.tsx
+++ b/src/components/Unit/Forms/AddMemberForm.tsx
@@ -8,7 +8,7 @@ import { lookupUser } from "../store";
 import { Dispatch } from "redux";
 import { UitsRole, IPerson, IUnitMember, IUnitMemberRequest } from "../../types";
 
-interface IFormProps extends InjectedFormProps<IUnitMemberRequest>, IUnitMember, IDispatchProps, IStateProps {}
+interface IFormProps extends InjectedFormProps<IUnitMemberRequest>, IUnitMember, IDispatchProps, IStateProps { }
 
 interface IDispatchProps {
   lookupUser: typeof lookupUser;
@@ -46,7 +46,8 @@ const form: React.SFC<IFormProps> = props => {
                         setPerson(user);
                       }}
                     >
-                      {user && user.name}
+                      {user && user.name} 
+                      {user && user.netId && <>  ({user.netId}) </>}
                     </Button>
                   </div>
                 );

--- a/src/components/Unit/Forms/UpdateMembersForm.tsx
+++ b/src/components/Unit/Forms/UpdateMembersForm.tsx
@@ -65,8 +65,10 @@ const form: React.SFC<IFormProps> = props => {
               unitId={unitId}
               initialValues={{ unitId }}
               onSubmit={(values: IUnitMember) => {
-                const { unitId, personId, title, showTitle, role, permissions, percentage, showPercentage } = values;
-                save({ unitId, personId, title, showTitle, role, permissions, percentage, showPercentage });
+                const netid = values.person ? values.person.netId : undefined;
+                const personId = values.person ? values.person.id : undefined;
+                const { unitId, title, showTitle, role, permissions, percentage, showPercentage } = values;
+                save({ unitId, netid, personId, title, showTitle, role, permissions, percentage, showPercentage });
                 closeModal();
               }}
             />

--- a/src/components/Unit/Forms/UpdateMembersForm.tsx
+++ b/src/components/Unit/Forms/UpdateMembersForm.tsx
@@ -65,10 +65,10 @@ const form: React.SFC<IFormProps> = props => {
               unitId={unitId}
               initialValues={{ unitId }}
               onSubmit={(values: IUnitMember) => {
-                const netid = values.person ? values.person.netId : undefined;
+                const netId = values.person ? values.person.netId : undefined;
                 const personId = values.person ? values.person.id : undefined;
                 const { unitId, title, showTitle, role, permissions, percentage, showPercentage } = values;
-                save({ unitId, netid, personId, title, showTitle, role, permissions, percentage, showPercentage });
+                save({ unitId, netId, personId, title, showTitle, role, permissions, percentage, showPercentage });
                 closeModal();
               }}
             />

--- a/src/components/Unit/store.ts
+++ b/src/components/Unit/store.ts
@@ -103,7 +103,7 @@ const edit = () => action(UnitActionTypes.UNIT_EDIT, {});
 const fetchUnit = (request: IEntityRequest) => action(UnitActionTypes.UNIT_FETCH_REQUEST, request);
 const lookupDepartment = (q: string) => lookup(q ? `/departments?q=${q}&_limit=${lookupLimit}` : "");
 const lookupUnit = (q: string) => lookup(q ? `/units?q=${q}&_limit=${lookupLimit}` : "");
-const lookupUser = (q: string) => lookup(q ? `/people?q=${q}&_limit=${lookupLimit}` : "");
+const lookupUser = (q: string) => lookup(q ? `/people-lookup?q=${q}&_limit=${lookupLimit}` : "");
 const saveMemberRequest = (member: IUnitMemberRequest) => action(UnitActionTypes.UNIT_SAVE_MEMBER_REQUEST, member);
 const saveUnitChild = (request: IEntityRequest) => action(UnitActionTypes.UNIT_SAVE_CHILD_REQUEST, request);
 const saveUnitDepartment = (request: ISupportRelationshipRequest) => action(UnitActionTypes.UNIT_SAVE_DEPARTMENT_REQUEST, request);
@@ -365,7 +365,7 @@ const saveMemberError = (error: Error) => action(UnitActionTypes.UNIT_SAVE_MEMBE
 function* handleSaveMember(api: IApi, member: IUnitMemberRequest) {
   const request = member.id
     ? api.put(apiEndpoints.memberships(member.id), member)
-    : api.post(apiEndpoints.memberships(member.id), member);
+    : api.post(apiEndpoints.memberships(), member);
   const action = yield request
     .then(_ => fetchUnitMembers({ id: member.unitId }))
     .catch(signinIfUnauthorized)

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -150,6 +150,7 @@ export interface IUnitMemberRequest {
   id?: number;
   unitId: number;
   personId?: number;
+  netid?: string;
   title: string;
   showTitle?: boolean;
   role: ItProRole | UitsRole | string;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -150,7 +150,7 @@ export interface IUnitMemberRequest {
   id?: number;
   unitId: number;
   personId?: number;
-  netid?: string;
+  netId?: string;
   title: string;
   showTitle?: boolean;
   role: ItProRole | UitsRole | string;

--- a/src/db.json
+++ b/src/db.json
@@ -155,6 +155,15 @@
       "permissions": "Editor",
       "role": "Leader",
       "title": "Manager"
+    },
+    {
+      "unitId": "4",
+      "netid": "garryg",
+      "personId": 5,
+      "title": "Person",
+      "role": "Member",
+      "percentage": 100,
+      "id": 6
     }
   ],
   "supportRelationships": [

--- a/src/db.json
+++ b/src/db.json
@@ -158,7 +158,6 @@
     },
     {
       "unitId": "4",
-      "netid": "garryg",
       "personId": 5,
       "title": "Person",
       "role": "Member",


### PR DESCRIPTION
Update membership form to account for adding members that are not in the database and do not have `personId` yet.

- [x] Create endpoint to query canonical people data 
- [x] Add 'netId' to membership request body to handle username not in the system yet
- [x] Update pact tests 