### PR TITLE
Add loading animation and debounce to people lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "db:admin": "yarn db --middlewares ./json_server/db.middleware.admin.js",
     "db:chaos": "yarn db --middlewares ./json_server/db.middleware.admin.js ./db.middleware.chaos.js",
     "db:user": "yarn db --middlewares ./json_server/db.middleware.user.js",
-    "db:slow": "yarn db --middlewares ./json_server/db.middleware.user.js ./json_server/db.middleware.slow.js",
+    "db:slow": "yarn db --middlewares ./json_server/db.middleware.admin.js ./json_server/db.middleware.slow.js",
     "db:switch": "yarn db --middlewares ./json_server/middleware.switcher.js",
     "dev": "server-test db $npm_package_config_dbport start",
     "dev:admin": "server-test db:admin $npm_package_config_dbport start",

--- a/src/components/lookup.ts
+++ b/src/components/lookup.ts
@@ -27,11 +27,13 @@ interface ILookupState {
   cache: {};
   q?: string;
   current?: any;
+  loading: boolean;
 }
 
 const initialState: ILookupState = {
   cache: {},
   q: "",
+  loading: false,
   current: null
 };
 
@@ -41,23 +43,23 @@ const reducer: Reducer = (state = initialState, action) => {
       if (action.payload == "") {
         return { ...state, current: null, q: "" };
       }
-      return { ...state, q: action.payload };
+      return { ...state, loading: true, q: action.payload };
     case LookupActionTypes.LOOKUP_FETCH_REQUESTED:
       return state;
     case LookupActionTypes.LOOKUP_FETCH_SUCCESS:
       let { data, url } = action.payload;
       url = new URL(url);
       const path = url.pathname + decodeURI(url.search);
-      let s = { ...state, current: data, cache: state.cache || {} };
+      let s = { ...state, current: data, loading: false, cache: state.cache || {} };
       s.cache[path] = data;
       return s;
     case LookupActionTypes.LOOKUP_FETCH_ERROR:
       // todo: action.payload is a caught exception Error object
-      return state;
+      return { ...state, loading: false };
     case LookupActionTypes.LOOKUP_GET_CACHED_SUCCESS:
-      return { ...state, current: action.payload };
+      return { ...state, current: action.payload, loading: false };
     case LookupActionTypes.LOOKUP_CLEAR_CURRENT:
-      return { ...state, current: null };
+      return { ...state, current: null, loading: false };
     default:
       return state;
   }


### PR DESCRIPTION
_Problem:_
The member lookup was being triggered on every change to the search input. This was creating unneeded API calls.

_Solution:_
Debounce events that trigger the API call.

- Added debounce to member lookup input change
- Added loading indictor on member lookup

![debounce member lookup](https://user-images.githubusercontent.com/862054/57399030-10a82980-7196-11e9-9fc5-cfdba051372c.gif)
