### PR TITLE
Use session storage for state and auth

### DIFF
--- a/cypress/e2e/tests.e2e.ts
+++ b/cypress/e2e/tests.e2e.ts
@@ -1,7 +1,10 @@
+const clearSessionStorage = (win: any) =>
+    win.sessionStorage.clear(); 
+
 describe('admin user', () => {
 
     it('creates new unit and deletes it', () => {
-        cy.visit('/')
+        cy.visit('/', { onBeforeLoad: clearSessionStorage })
         cy.getAllByText(/log in/i).last().click()
         cy.getByText(/units/i).click()
         cy.getAllByText(/add new unit/i).first().click()
@@ -16,7 +19,7 @@ describe('admin user', () => {
     })
 
     it('adds unit member & tool -> removes them', () => {
-        cy.visit('/')
+        cy.visit('/', { onBeforeLoad: clearSessionStorage })
         cy.getAllByText(/log in/i).last().click()
         cy.visit('/units/2')
         cy.getByTitle(/edit/i).click()
@@ -45,7 +48,7 @@ describe('admin user', () => {
 describe('standard user', () => {
 
     it('cannot edit or delete a unit', () => {
-        cy.visit('/')
+        cy.visit('/', { onBeforeLoad: clearSessionStorage })
         cy.getAllByText(/log in/i).last().click()
         cy.visit('/units/1')
         cy.queryByTitle(/edit:/i).should("not.be.visible")
@@ -56,7 +59,7 @@ describe('standard user', () => {
 describe('unit leader', () => {
 
     it('can edit unit, members & tools', () => {
-        cy.visit('/')
+        cy.visit('/', { onBeforeLoad: clearSessionStorage })
         cy.getAllByText(/log in/i).last().click()
         cy.visit('/units/4')
         cy.queryByTitle(/delete:/i).should("not.be.visible")

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -103,7 +103,7 @@ export interface IApiCall {
   <T>(method: string, url: string, path: string, data?: T, headers?: any): Promise<IApiResponse<T>>;
 }
 
-const getAuthToken = () => localStorage.getItem("authToken");
+const getAuthToken = () => sessionStorage.getItem("authToken");
 
 const getPermissions = (headers: Headers): Permission[] =>
   (headers.get("X-User-Permissions") + "")

--- a/src/components/effects.ts
+++ b/src/components/effects.ts
@@ -6,12 +6,12 @@ import { signInRequest } from "./SignIn/store";
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const clearApplicationData = () => localStorage.clear();
+const clearApplicationData = () => sessionStorage.clear();
 
-const getAuthToken = () => localStorage.getItem("authToken");
+const getAuthToken = () => sessionStorage.getItem("authToken");
 
 const setAuthToken = (token: string) =>
-  localStorage.setItem("authToken", token);
+  sessionStorage.setItem("authToken", token);
 
 
 const redirectToLogin = () =>

--- a/src/components/effects.ts
+++ b/src/components/effects.ts
@@ -6,7 +6,10 @@ import { signInRequest } from "./SignIn/store";
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-const clearApplicationData = () => sessionStorage.clear();
+const clearApplicationData = () => {
+  localStorage.clear();
+  sessionStorage.clear();
+}
 
 const getAuthToken = () => sessionStorage.getItem("authToken");
 

--- a/src/configureStore.ts
+++ b/src/configureStore.ts
@@ -100,7 +100,7 @@ export function* rootSaga() {
 // Otherwise, return the default initial state.
 const loadState = (): IApplicationState => {
   try {
-    const serializedState = localStorage.getItem("state");
+    const serializedState = sessionStorage.getItem("state");
     if (serializedState) {
     //   console.log("Initializing state from session storage");
       return JSON.parse(serializedState);
@@ -118,7 +118,7 @@ const loadState = (): IApplicationState => {
 const saveState = (state: IApplicationState) => {
   try {
     const serializedState = JSON.stringify(state);
-    localStorage.setItem("state", serializedState);
+    sessionStorage.setItem("state", serializedState);
   } catch (err) {
     // Ignore write errors
   }


### PR DESCRIPTION
Session storage is better than local storage for a couple reasons:
* Tabs can interact with the app independently
* Stale data is less of a problem
* Auth tokens are destroyed when the tab/window closes.