### PR TITLE
Leave edit mode when fetching a different unit and after saving a unit.

### DIFF
--- a/src/components/Unit/store.ts
+++ b/src/components/Unit/store.ts
@@ -159,13 +159,13 @@ const reducer: Reducer<IState> = (state = initialState, act) => {
     case UnitActionTypes.UNIT_FETCH_PROFILE_REQUEST:
       return { ...state, profile: TaskStartReducer(state.profile, act), parent: defaultState() };
     case UnitActionTypes.UNIT_FETCH_PROFILE_SUCCESS:
-      return { ...state, profile: TaskSuccessReducer(state.profile, act) };
+      return { ...state, profile: TaskSuccessReducer(state.profile, act), view: ViewStateType.Viewing };
     case UnitActionTypes.UNIT_FETCH_PROFILE_ERROR:
       return { ...state, profile: TaskErrorReducer(state.profile, act) };
     case UnitActionTypes.UNIT_SAVE_PROFILE_REQUEST:
       return { ...state, profile: TaskStartReducer(state.profile, act) };
     case UnitActionTypes.UNIT_SAVE_PROFILE_SUCCESS:
-      return { ...state, profile: TaskSuccessReducer(state.profile, act) };
+      return { ...state, profile: TaskSuccessReducer(state.profile, act), view: ViewStateType.Viewing };
     case UnitActionTypes.UNIT_SAVE_PROFILE_ERROR:
       return { ...state, profile: TaskErrorReducer(state.profile, act) };
     case UnitActionTypes.UNIT_DELETE_REQUEST:


### PR DESCRIPTION
While editing a unit a user can navigate to a parent or child unit. The app remains in 'edit' mode, giving the user the impression that they can edit a unit they don't own. The server rejects any attempted modification, but nonetheless it understandably freaks out the users.

This PR returns to the unit page to 'viewing' mode after saving changes to the unit, or navigating to a new unit. 