### PR TITLE
Show Support Types on Department view

### DIFF
--- a/json_server/db.routes.json
+++ b/json_server/db.routes.json
@@ -8,6 +8,6 @@
   "/people-lookup?q=:term": "/people?q=:term",
   "/departments/:id/members": "/people?departmentId=:id",
   "/departments/:id/memberUnits": "/units?id=1&id=2&id=4",
-  "/departments/:id/supportingUnits": "/supportRelationships?departmentId=:id&_expand=unit",
+  "/departments/:id/supportingUnits": "/supportRelationships?departmentId=:id&_expand=unit&_expand=supportType&_expand=department",
   "/buildings/:id/supportingUnits": "/buildingRelationships?buildingId=:id&_expand=unit"
 }

--- a/src/components/Department/Presentation/View.tsx
+++ b/src/components/Department/Presentation/View.tsx
@@ -32,9 +32,9 @@ export const View: React.SFC<IState> = ({ profile, memberUnits, supportingUnits 
                               <span style={{ fontSize: "smaller" }}>({r.supportType?.name})</span>
                             </div>
                             )}
-                            {r.department.description && (   
+                            {r.unit.description && (   
                               <div>
-                                <span>{r.department.description}</span>
+                                <span>{r.unit.description}</span>
                               </div>
                             )}
                         </li>)}

--- a/src/components/Department/Presentation/View.tsx
+++ b/src/components/Department/Presentation/View.tsx
@@ -1,14 +1,12 @@
 import * as React from "react";
 import { Breadcrumbs, Content } from "src/components/layout";
-import { Row, Col } from "rivet-react";
+import { Row, Col, List } from "rivet-react";
 import { Loader } from "src/components/Loader";
 import { IState } from "../store";
-import { UnitList } from "src/components/Units/UnitList";
 import { Profile } from ".";
+import { Panel } from "src/components/Panel";
 
 export const View: React.SFC<IState> = ({ profile, memberUnits, supportingUnits }) => {
-  console.log("***memberUnits***", memberUnits);
-  console.log ("***supportingUnits***", supportingUnits);
   return <>
     <Breadcrumbs crumbs={[{ text: "Home", href: "/" }, "Departments", profile && profile.data ? profile.data.name : "..."]} />
     <Content className="rvt-bg-white rvt-m-tb-xl rvt-p-tb-xl">
@@ -22,7 +20,33 @@ export const View: React.SFC<IState> = ({ profile, memberUnits, supportingUnits 
       <Row>
         <Col md={6} className="rvt-p-lr-md">
           <Loader {...supportingUnits}>
-            { supportingUnits.data && <UnitList units={supportingUnits.data.map(r => r.unit).filter(u => u)} title="Supporting Units" /> }
+            <div className="rvt-m-bottom-xl">
+              <Panel title="Supporting Units">
+                  { supportingUnits && supportingUnits.data && supportingUnits.data.length !== 0 &&
+                    <List variant="plain">
+                      {supportingUnits.data.map((r, i) => 
+                        <li key={"unit:" + i}>
+                          <a href={`/units/${r.unit.id}`}>{r.unit.name}</a>
+                            {r.supportType && (
+                            <div>
+                              <span style={{ fontSize: "smaller" }}>({r.supportType?.name})</span>
+                            </div>
+                            )}
+                            {r.department.description && (   
+                              <div>
+                                <span>{r.department.description}</span>
+                              </div>
+                            )}
+                        </li>)}
+                    </List>
+                    }
+                  { 
+                    !supportingUnits || !supportingUnits.data || supportingUnits.data.length === 0 && 
+                      <p>No units found.</p> 
+                  }
+              </Panel>
+              </div>
+              {/* { supportingUnits.data && <UnitList units={supportingUnits.data.map(r => r.unit).filter(u => u)} title="Supporting Units" /> } */}
           </Loader>
         </Col>
       </Row>

--- a/src/components/Unit/Presentation/Departments.tsx
+++ b/src/components/Unit/Presentation/Departments.tsx
@@ -21,16 +21,14 @@ const Departments: React.SFC<IDefaultState<ISupportRelationship[]>> = props => {
               .map((supportRelationship, i) => (
                 <li key={i}>
                   <a href={`/departments/${supportRelationship.department.id}`}>{supportRelationship.department.name}</a> 
+                  {supportRelationship.supportType && (
+                    <div>
+                      <span style={{ fontSize: "smaller" }}>({supportRelationship.supportType?.name})</span>
+                    </div>
+                  )}
                   {supportRelationship.department.description && (
                     <div>
-                      {supportRelationship.supportType && (
-                      <div>
-                        <span style={{ fontSize: "smaller" }}>({supportRelationship.supportType?.name})</span>
-                      </div>
-                      )}
-                      <div>
-                        <span style={{ fontSize: "smaller" }}>{supportRelationship.department.description}</span>
-                      </div>
+                      <span style={{ fontSize: "smaller" }}>{supportRelationship.department.description}</span>
                     </div>
                   )}
                 </li>


### PR DESCRIPTION
Unfortunately, we can't reuse the unitsList component here as Corey would like to see supportType related things.

Also, I'm fixing a conditional that's used similarly elsewhere about if the description is null, we still want to show the support type.

![image](https://user-images.githubusercontent.com/2359966/130673951-3325963a-e078-47b2-ab14-302e3cbbfe19.png)
