### PR TITLE
Membertools Error Handling

### DIFF
--- a/json_server/db.middleware.routes.js
+++ b/json_server/db.middleware.routes.js
@@ -30,6 +30,36 @@ module.exports = (req, res, next) => {
     res.status(204);
     return res.end();
   }
+
+  if(req.method == "POST" && req.path.startsWith("/memberTools") && req.path.endsWith("/memberTools"))
+  {
+    // If someone assigns a tool to Li’l Sebastian throw a 400 error to handle.
+    console.log(req.body);
+    // let body = JSON.parse(req.body);
+    let membership = db.memberships.find(m => m.id == req.body.membershipId);
+    if(membership == null){
+      res.status(404);
+      return next();
+    }
+
+    let person = db.people.find(p => p.id == membership.personId);
+    if(person == null){
+      res.status(404);
+      return next();
+    }
+    
+    if(person.netId == "lsebastian") {
+      res.status(400);
+      // console.log(res);
+      let error = {
+        "statusCode": 400,
+        "errors": [ "Li’l Sebastian is a horse, and cannot use tools." ],
+        "details": "Enough horsing around."
+      };
+      return res.send(error);
+    }
+  }
+
   // GET /people/**
   if (req.method != "GET") {
     return next();

--- a/src/components/Unit/store.ts
+++ b/src/components/Unit/store.ts
@@ -536,7 +536,10 @@ function* handleDeleteBuildingRelationship(api: IApi, supportRelationship: IBuil
 }
 
 type SaveMemberToolsRequest = {member:IUnitMember, tools:number[]}
-const saveMemberToolsError = (error: Error) => action(UnitActionTypes.UNIT_SAVE_MEMBER_TOOLS_ERROR, error);
+const saveMemberToolsError = (error: Error) => {
+  alert(error.message)
+  return action(UnitActionTypes.UNIT_SAVE_MEMBER_TOOLS_ERROR, error);
+}
 function* handleSaveMemberTools(api: IApi, {member, tools}: SaveMemberToolsRequest) {
   // Find all the tools to add
   const oldToolIds = new Set(member.memberTools.map(mt => mt.toolId));


### PR DESCRIPTION
When a request to `POST` or `DELETE` to `/membertools` fails an alert is now raised so it doesn't fail silently.

I wanted the error to display in the modal, but that will be a lot of extra work.  We can save that for when we re-implement the front end.